### PR TITLE
EC2 Compute Instances with Security Groups for Traffic Handling

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,3 +24,11 @@ module "vpc" {
   project = "AWS-POC"
   environment = "Sandbox"
 }
+
+module "instances" {
+  source = "./modules/instances"
+  aws_vpc = module.vpc.vpc_id
+  private_subnet_id = module.vpc.private_subnet3_id
+  public_subnet_id = module.vpc.public_subnet1_id
+  key_name = "ec2-test"
+}

--- a/modules/instances/apache_install.sh
+++ b/modules/instances/apache_install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+dnf update
+dnf install httpd
+systemctl enable httpd
+systemctl start httpd

--- a/modules/instances/private_subnet_instance.tf
+++ b/modules/instances/private_subnet_instance.tf
@@ -1,0 +1,33 @@
+data "aws_vpc" "default" {
+  id = var.aws_vpc
+}
+
+data "aws_ami" "redhat_linux_private" {
+  most_recent = true
+  owners = ["309956199498"]
+
+  filter {
+    name = "name"
+    values = [var.ami]
+  }
+}
+
+resource "aws_instance" "sub3_instance" {
+  ami = data.aws_ami.redhat_linux_private.id
+  instance_type = var.instance_type
+  subnet_id = var.private_subnet_id
+  key_name = var.key_name
+  security_groups = [aws_security_group.ec2_allow_ssh.id]
+  user_data = file("${path.module}/apache_install.sh")
+
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = 20
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "PrivateEC2Apache"
+  }
+}
+

--- a/modules/instances/public_subnet_instance.tf
+++ b/modules/instances/public_subnet_instance.tf
@@ -1,0 +1,29 @@
+data "aws_ami" "redhat_linux_public" {
+  most_recent = true
+  owners = ["309956199498"]
+
+  filter {
+    name = "name"
+    values = [var.ami]
+  }
+}
+
+resource "aws_instance" "sub1_instance" {
+  ami = data.aws_ami.redhat_linux_public.id
+  instance_type = var.instance_type
+  security_groups = [aws_security_group.ec2_allow_ssh.id,aws_security_group.ec2_allow_http.id]
+  subnet_id = var.public_subnet_id
+  key_name = var.key_name
+  associate_public_ip_address = true
+
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = 20
+    delete_on_termination = true
+  }
+
+  tags = {
+    Name = "PublicEC2Base"
+  }
+}
+

--- a/modules/instances/security_groups.tf
+++ b/modules/instances/security_groups.tf
@@ -1,0 +1,40 @@
+resource "aws_security_group" "ec2_allow_ssh" {
+  name = "ec2_allow_ssh"
+  description = "Allow SSH inbound and outbound traffic"
+  vpc_id = data.aws_vpc.default.id
+
+  ingress {
+    from_port = 22
+    protocol = "tcp"
+    to_port = 22
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port = 0
+    protocol = "-1"
+    to_port = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ec2_allow_http" {
+  name = "ec2_allow_http"
+  description = "Allow HTTP inbound and outbound traffic"
+  vpc_id = data.aws_vpc.default.id
+
+  ingress {
+    from_port = 80
+    protocol = "tcp"
+    to_port = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port = 0
+    protocol = "-1"
+    to_port = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -1,0 +1,23 @@
+variable "region" {
+  default = "us-east-1"
+}
+
+variable "instance_type" {
+  default = "t2.micro"
+}
+
+# Amazon Linux AMI
+variable "ami" {
+  default = "RHEL*x86*"
+}
+
+variable "volume_size" {
+  default = "20"
+}
+
+variable "key_name" {}
+
+variable "public_subnet_id" {}
+variable "private_subnet_id" {}
+variable "aws_vpc" {}
+


### PR DESCRIPTION
Adding capabilities for:
- EC2 instances in sub1 (public) and sub3 (private)
- Security groups corresponding to EC2 instances
- RHEL installed on both instances, with sub3 having an additional installation of Apache
- SSH availability into sub1's EC2 instance (note: this requires downloading of a key pair generation)